### PR TITLE
Fix client component issue in quiz.tsx

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,5 +1,4 @@
 import { Sidebar } from "@/components/navigation/sidebar"
-import Quiz from "@/components/interactive/quiz"
 
 export default function Documents({
   children,
@@ -11,18 +10,6 @@ export default function Documents({
       <Sidebar />
       <div className="flex-1 md:flex-[6]">
         {children}
-        <Quiz questions={[
-          {
-            question: "What is React?",
-            options: ["Library", "Framework", "Language"],
-            correctAnswer: "Library"
-          },
-          {
-            question: "What is JSX?",
-            options: ["JavaScript XML", "JavaScript Extension", "Java Syntax"],
-            correctAnswer: "JavaScript XML"
-          }
-        ]} />
       </div>
     </div>
   )

--- a/components/interactive/quiz.tsx
+++ b/components/interactive/quiz.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 
 type Question = {


### PR DESCRIPTION
Add "use client" directive to `components/interactive/quiz.tsx`.

Remove the import statement for `Quiz` component and its usage from `app/docs/layout.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thuggys/webbb/pull/3?shareId=fe7d3dd3-859a-4de0-961c-74dd85ef138b).