### PR TITLE
Add new dark grey/black with purple vibe color scheme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,12 @@
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;
     --radius: 0.5rem;
+
+    /* New color variables for dark grey/black with purple vibe */
+    --dark-grey: 240 5% 10%;
+    --black: 240 5% 5%;
+    --purple-vibe: 270 50% 40%;
+    --purple-vibe-foreground: 270 50% 90%;
   }
 
   .dark {
@@ -33,18 +39,18 @@
     --card-foreground: 0 0% 98%;
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
+    --primary: var(--purple-vibe);
+    --primary-foreground: var(--purple-vibe-foreground);
+    --secondary: var(--dark-grey);
     --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
+    --muted: var(--dark-grey);
     --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
+    --accent: var(--dark-grey);
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
+    --border: var(--dark-grey);
+    --input: var(--dark-grey);
     --ring: 240 4.9% 83.9%;
   }
 }

--- a/components/interactive/quiz.tsx
+++ b/components/interactive/quiz.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 
 type Question = {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,13 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        // New color scheme for dark grey/black with purple vibe
+        darkGrey: "hsl(var(--dark-grey))",
+        black: "hsl(var(--black))",
+        purpleVibe: {
+          DEFAULT: "hsl(var(--purple-vibe))",
+          foreground: "hsl(var(--purple-vibe-foreground))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
Add new color scheme for dark grey/black with purple vibe.

* **app/globals.css**
  - Add new color variables for dark grey/black with purple vibe.
  - Update the `.dark` class to use the new color variables.

* **tailwind.config.ts**
  - Add new color scheme to the `extend.colors` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thuggys/webbb/pull/4?shareId=bf81db57-577c-4791-bb77-0cca9a0032bb).